### PR TITLE
Add the possibility of cancelling the authentication process.

### DIFF
--- a/GreeterConnection.cpp
+++ b/GreeterConnection.cpp
@@ -160,6 +160,11 @@ void GreeterConnection::showError(std::string error)
     m_out.flush();
 }
 
+void GreeterConnection::setCancelAuthHandler(GreeterConnection::CancelAuthHandler cancelAuthHandler)
+{
+    m_cancelAuthHandler = cancelAuthHandler;
+}
+
 void GreeterConnection::sendSessions()
 {
     auto sessions = m_greeterManager.sessionList();
@@ -209,6 +214,11 @@ void GreeterConnection::receive()
         std::string password;
         m_in >> password;
         m_credentialsHandler(username, password);
+        return;
+    }
+
+    if (cmd == "CANCEL") {
+        m_cancelAuthHandler();
         return;
     }
 }

--- a/GreeterConnection.h
+++ b/GreeterConnection.h
@@ -54,6 +54,7 @@ public:
     typedef std::function<void(int)> OpenSessionHandler;
     typedef std::function<void(std::string)> PasswordHandler;
     typedef std::function<void(std::string, std::string)> CredentialsHandler;
+    typedef std::function<void(void)> CancelAuthHandler;
 
 public:
     /**
@@ -95,6 +96,13 @@ public:
      * @param credentialsHandler Handler that will be called once the credentials are received.
      */
     void askForCredentials(CredentialsHandler credentialsHandler);
+    
+    /**
+     * @brief Set handler that will cancel the authentication process.
+     *
+     * @param cancelAuthHandler Handler that will be called on cancel authentication event.
+     */
+    void setCancelAuthHandler(CancelAuthHandler cancelAuthHandler);
 
     /**
      * Send request to show error to the greeter program.
@@ -123,6 +131,7 @@ private:
     OpenSessionHandler m_openSessionHandler;
     PasswordHandler m_passwordHandler;
     CredentialsHandler m_credentialsHandler;
+    CancelAuthHandler m_cancelAuthHandler;
 
     pid_t m_greeterPID;
 

--- a/VncTunnel.cpp
+++ b/VncTunnel.cpp
@@ -91,7 +91,7 @@ void VncTunnel::start()
 
                 select();
             } catch (XvncConnection::ConnectionException &e) {
-                if (m_greeterConnection) {
+                if (m_greeterConnection && e.showInGreeter()) {
                     m_greeterConnection->showError(e.what());
                 }
 
@@ -744,6 +744,9 @@ void VncTunnel::switchToConnection(std::shared_ptr<Xvnc> xvnc)
     m_selector.cancel();
 
     assert(m_greeterConnection);
+
+    m_greeterConnection->setCancelAuthHandler(std::bind(&XvncConnection::handleCancelAuthentication, m_potentialConnection));
+
     m_potentialConnection->initialize(
         std::bind(&VncTunnel::connectionSwitched, this),
         std::bind(&GreeterConnection::askForPassword, m_greeterConnection, std::placeholders::_1),

--- a/Xvnc.cpp
+++ b/Xvnc.cpp
@@ -226,6 +226,7 @@ void Xvnc::execute(bool queryDisplayManager)
             "-securitytypes=none",
             "-displayfd", displayNumberPipeText.c_str(),
             "-geometry", Configuration::options["geometry"].as<std::string>().c_str(),
+            "-BlacklistTimeout=0",
             "-AllowOverride="
                 // These parameters are normally allowed by default
                 "Desktop,AcceptPointerEvents,SendCutText,AcceptCutText,"

--- a/XvncConnection.cpp
+++ b/XvncConnection.cpp
@@ -187,6 +187,11 @@ void XvncConnection::handleVncAuthSecurityWithPassword(std::string password)
     completeInitialization();
 }
 
+void XvncConnection::handleCancelAuthentication()
+{
+    throw ConnectionException(this, "Cancelled authentication", false);
+}
+
 void XvncConnection::handleVeNCryptSecurity()
 {
     // Receive server's VeNCrypt version

--- a/XvncConnection.h
+++ b/XvncConnection.h
@@ -59,14 +59,17 @@ public:
     class ConnectionException : public std::runtime_error
     {
     public:
-        ConnectionException(const XvncConnection *faultyConnection, std::string message)
-            : std::runtime_error(message), m_faultyConnection(faultyConnection)
+        ConnectionException(const XvncConnection *faultyConnection, std::string message, bool showGreeter = true)
+            : std::runtime_error(message), m_faultyConnection(faultyConnection), m_showGreeter(showGreeter)
         {}
 
         const XvncConnection *faultyConnection() const { return m_faultyConnection; }
 
+        bool showInGreeter() const { return m_showGreeter; }
+
     private:
         const XvncConnection *m_faultyConnection;
+        bool m_showGreeter;
     };
 
 public:
@@ -105,6 +108,11 @@ public:
      * Stream format on top of the stream used to communicate with the VNC server.
      */
     StreamFormatter &fmt() { return m_streamFormatter; }
+
+    /**
+     * Cancel authentication process if greeter asks.
+     */
+    void handleCancelAuthentication();
 
     uint16_t framebufferWidth() const { return m_framebufferWidth; }
     uint16_t framebufferHeight() const { return m_framebufferHeight; }


### PR DESCRIPTION
With the update of vncmanager-greeter (https://github.com/openSUSE/vncmanager-greeter/commit/341b7ca65f6626d6ba223235c416048400ad8438), now the authentication process can be cancelled.
This request handles that cancellation event.